### PR TITLE
refactor(infra): use individual env vars for connection IDs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ See `env.sample` for complete list. Key variables:
 - liteLLM API key and base URL (`LITELLM_API_KEY`, `LITELLM_BASE_URL`)
 - Model name for routing (`OPENAI_MODEL` - e.g., gpt-4o-mini)
 - PostgreSQL connection string
-- `ENABLED_CONNECTIONS`: JSON map of connection names to Auth0 connection IDs. Controls which integrations are available. Keys are: `google-oauth2`, `windowslive`, `salesforce`, `xbox`. Remove a key to disable that integration.
+- Connection enablement via individual env vars (`GOOGLE_CONNECTION_ID`, `MICROSOFT_CONNECTION_ID`, `SALESFORCE_CONNECTION_ID`, `XBOX_CONNECTION_ID`). Set to Auth0 connection ID to enable, leave unset to disable.
 - Google Custom Search API credentials (for web search)
 
 ## Development Guidelines
@@ -195,7 +195,7 @@ See `env.sample` for complete list. Key variables:
 2. Create provider file in `lib/auth0-ai/<provider>.ts` with scope-specific wrappers
 3. Create tools directory: `lib/ai/tools/<provider>/`
 4. Implement tools following existing patterns
-5. Add provider to `ENABLED_CONNECTIONS` environment variable
+5. Add provider's connection env var (e.g., `<PROVIDER>_CONNECTION_ID`)
 
 ### Prisma Workflow
 
@@ -251,7 +251,7 @@ Defined in `getSystemTemplate()` in `app/api/chat/route.ts`. Includes:
 ### Debugging Token Issues
 
 1. Check `lib/auth0-ai/<provider>.ts` for correct scope definitions
-2. Verify `ENABLED_CONNECTIONS` mapping in `.env.local`
+2. Verify `<PROVIDER>_CONNECTION_ID` is set in `.env.local`
 3. Check Auth0 connection configuration (scopes must be enabled)
 4. Use browser DevTools Network tab to inspect token exchange
 

--- a/env.sample
+++ b/env.sample
@@ -26,11 +26,12 @@ SALESFORCE_LOGIN_URL="https://{TENANT}.develop.my.salesforce.com"
 # this demo requires a local Postgresql DB
 DATABASE_URL="postgresql://{USER}@localhost:5432/chatbot?schema=public&sslmode=disable"
 
-# Connections map - controls which integrations are enabled
-# Keys are connection names: google-oauth2, windowslive, salesforce, xbox
-# Values are Auth0 connection IDs (con_xxxxx)
-# Remove a connection from this JSON to disable it
-ENABLED_CONNECTIONS='{"google-oauth2":"con_xxxxxx","windowslive":"con_xxxxxx","salesforce":"con_xxxxxx","xbox":"con_xxxxxx"}'
+# Enabled connections - set to Auth0 connection ID (con_xxxxx) to enable
+# Leave unset or empty to disable the integration
+GOOGLE_CONNECTION_ID="con_xxxxxx"
+MICROSOFT_CONNECTION_ID="con_xxxxxx"
+SALESFORCE_CONNECTION_ID="con_xxxxxx"
+XBOX_CONNECTION_ID="con_xxxxxx"
 
 # for web search you need to set up Google Custom search API
 # https://developers.google.com/custom-search/v1/overview

--- a/lib/config/enabled-connections.ts
+++ b/lib/config/enabled-connections.ts
@@ -1,44 +1,36 @@
 /**
- * Utility for managing enabled connections via ENABLED_CONNECTIONS env var.
+ * Utility for managing enabled connections via individual environment variables.
  *
- * Format: JSON object mapping connection names to connection IDs (or true to enable)
- * Example: '{"google-oauth2":"con_xxx","windowslive":"con_xxx","salesforce":"con_xxx","xbox":"con_xxx"}'
+ * Environment variables:
+ * - GOOGLE_CONNECTION_ID=con_xxx     → enables google-oauth2
+ * - MICROSOFT_CONNECTION_ID=con_xxx  → enables windowslive
+ * - SALESFORCE_CONNECTION_ID=con_xxx → enables salesforce
+ * - XBOX_CONNECTION_ID=con_xxx       → enables xbox
  *
- * Connection names correspond to the "connection" field in ConnectionsMetadata:
- * - google-oauth2 (Google)
- * - windowslive (Microsoft)
- * - salesforce (Salesforce)
- * - xbox (Xbox)
+ * Set the env var to the Auth0 connection ID to enable, or leave unset to disable.
  */
-
-type EnabledConnectionsConfig = Record<string, string | boolean>
-
-let cachedConfig: EnabledConnectionsConfig | null = null
 
 /**
- * Parse and cache the ENABLED_CONNECTIONS environment variable.
- * Returns an empty object if not set or invalid.
+ * Mapping from connection names to their environment variable names.
  */
-function getConfig(): EnabledConnectionsConfig {
-  if (cachedConfig !== null) {
-    return cachedConfig
-  }
+const ConnectionEnvVarMap: Record<string, string> = {
+  "google-oauth2": "GOOGLE_CONNECTION_ID",
+  windowslive: "MICROSOFT_CONNECTION_ID",
+  salesforce: "SALESFORCE_CONNECTION_ID",
+  xbox: "XBOX_CONNECTION_ID",
+}
 
-  const envValue = process.env.ENABLED_CONNECTIONS
-  if (!envValue) {
-    console.warn("[EnabledConnections] ENABLED_CONNECTIONS not set, all connections disabled")
-    cachedConfig = {}
-    return cachedConfig
+/**
+ * Get the connection ID for a connection from its environment variable.
+ * Returns undefined if not set.
+ */
+function getConnectionIdFromEnv(connectionName: string): string | undefined {
+  const envVarName = ConnectionEnvVarMap[connectionName]
+  if (!envVarName) {
+    return undefined
   }
-
-  try {
-    cachedConfig = JSON.parse(envValue) as EnabledConnectionsConfig
-    return cachedConfig
-  } catch (error) {
-    console.error("[EnabledConnections] Failed to parse ENABLED_CONNECTIONS:", error)
-    cachedConfig = {}
-    return cachedConfig
-  }
+  const value = process.env[envVarName]
+  return value && value.trim() !== "" ? value.trim() : undefined
 }
 
 /**
@@ -46,8 +38,7 @@ function getConfig(): EnabledConnectionsConfig {
  * @param connectionName - The connection name (e.g., "google-oauth2", "salesforce")
  */
 export function isConnectionEnabled(connectionName: string): boolean {
-  const config = getConfig()
-  return connectionName in config && !!config[connectionName]
+  return !!getConnectionIdFromEnv(connectionName)
 }
 
 /**
@@ -56,20 +47,16 @@ export function isConnectionEnabled(connectionName: string): boolean {
  * @returns The connection ID or undefined if not enabled
  */
 export function getConnectionId(connectionName: string): string | undefined {
-  const config = getConfig()
-  const value = config[connectionName]
-  if (typeof value === "string") {
-    return value
-  }
-  return undefined
+  return getConnectionIdFromEnv(connectionName)
 }
 
 /**
  * Get list of all enabled connection names.
  */
 export function getEnabledConnectionNames(): string[] {
-  const config = getConfig()
-  return Object.keys(config).filter(key => !!config[key])
+  return Object.keys(ConnectionEnvVarMap).filter(connectionName =>
+    isConnectionEnabled(connectionName)
+  )
 }
 
 /**
@@ -103,8 +90,9 @@ export function getEnabledProviders(): ProviderName[] {
 }
 
 /**
- * Clear the cached config (useful for testing or when env var changes).
+ * Get the environment variable name for a connection.
+ * Useful for debugging or documentation.
  */
-export function clearCache(): void {
-  cachedConfig = null
+export function getEnvVarNameForConnection(connectionName: string): string | undefined {
+  return ConnectionEnvVarMap[connectionName]
 }

--- a/scripts/deploy/DEPLOYMENT.md
+++ b/scripts/deploy/DEPLOYMENT.md
@@ -56,7 +56,10 @@ APP_BASE_URL="http://localhost:3000"
 # Shared values
 OPENAI_API_KEY="sk-..."
 OPENAI_MODEL="gpt-4o-mini"
-ENABLED_CONNECTIONS='{"google-oauth2":"con_xxx"}'
+
+# Enabled connections (set to Auth0 connection ID to enable)
+GOOGLE_CONNECTION_ID="con_xxx"
+MICROSOFT_CONNECTION_ID="con_xxx"
 ```
 
 ### Example: .env.vercel (shared Vercel config)
@@ -78,7 +81,10 @@ APP_BASE_URL="https://preview.example.com"
 # Shared values
 OPENAI_API_KEY="sk-..."
 OPENAI_MODEL="gpt-4o-mini"
-ENABLED_CONNECTIONS='{"google-oauth2":"con_xxx"}'
+
+# Enabled connections (set to Auth0 connection ID to enable)
+GOOGLE_CONNECTION_ID="con_xxx"
+MICROSOFT_CONNECTION_ID="con_xxx"
 ```
 
 ### Example: .env.production (production overrides only)

--- a/scripts/deploy/vercel-env-sync.sh
+++ b/scripts/deploy/vercel-env-sync.sh
@@ -91,8 +91,15 @@ REQUIRED_VARS=(
     "DATABASE_URL"
     "OPENAI_API_KEY"
     "OPENAI_MODEL"
-    "ENABLED_CONNECTIONS"
     "GNEWS_API_KEY"
+)
+
+# Connection enablement vars (at least one recommended)
+CONNECTION_VARS=(
+    "GOOGLE_CONNECTION_ID"
+    "MICROSOFT_CONNECTION_ID"
+    "SALESFORCE_CONNECTION_ID"
+    "XBOX_CONNECTION_ID"
 )
 
 OPTIONAL_VARS=(
@@ -115,7 +122,7 @@ OPTIONAL_VARS=(
     "MERCHANT_IDLINK_CLIENT_SECRET"
 )
 
-ALL_VARS=("${AUTH0_VARS[@]}" "${REQUIRED_VARS[@]}" "${OPTIONAL_VARS[@]}")
+ALL_VARS=("${AUTH0_VARS[@]}" "${REQUIRED_VARS[@]}" "${CONNECTION_VARS[@]}" "${OPTIONAL_VARS[@]}")
 
 # Function to check if variable exists in a file
 var_in_file() {
@@ -205,6 +212,32 @@ if [ "$missing_required" = true ]; then
     echo ""
     echo -e "${RED}Error: Missing required variables${NC}"
     exit 1
+fi
+
+echo ""
+echo -e "${YELLOW}Connection Variables (set to enable integrations):${NC}"
+has_connection=false
+for var in "${CONNECTION_VARS[@]}"; do
+    vercel_value=$(get_var_from_file "$var" ".env.vercel")
+    prod_value=$(get_var_from_file "$var" ".env.production")
+
+    if [ -n "$vercel_value" ] || [ -n "$prod_value" ]; then
+        has_connection=true
+        if [ -n "$prod_value" ]; then
+            echo -e "  ${GREEN}✓${NC} $var"
+            echo -e "      ${BLUE}preview/dev${NC}: .env.vercel"
+            echo -e "      ${CYAN}production${NC}:  .env.production"
+        else
+            echo -e "  ${GREEN}✓${NC} $var ${BLUE}← .env.vercel (all environments)${NC}"
+        fi
+    else
+        echo -e "  ${YELLOW}⚠${NC} $var (not set - integration disabled)"
+    fi
+done
+
+if [ "$has_connection" = false ]; then
+    echo ""
+    echo -e "  ${YELLOW}Note: No connections enabled. Users won't be able to link accounts.${NC}"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

- Replaced `ENABLED_CONNECTIONS` JSON environment variable with individual env vars per connection
- Added `GOOGLE_CONNECTION_ID`, `MICROSOFT_CONNECTION_ID`, `SALESFORCE_CONNECTION_ID`, `XBOX_CONNECTION_ID`
- Simplified `lib/config/enabled-connections.ts` by removing JSON parsing and caching logic
- Updated deployment scripts to sync the new connection variables

## Motivation

JSON strings in environment variables were getting corrupted during Vercel deployment (quotes stripped, special characters mangled). Using individual env vars is more robust and easier to configure in Vercel's dashboard.

## Test plan

- [ ] Verify connections can be enabled/disabled via individual env vars in local dev
- [ ] Deploy to Vercel preview and verify integrations work correctly
- [ ] Confirm `npm run deploy:env:dry` shows the new connection variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)